### PR TITLE
Fix dead-link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ npm install mauler
 Games
 -----
 
-- [Tic-Tac-Toe](http://github.com/davidrobles/mauler/blob/master/src/games/tic-tac-toe/tic-tac-toe.js)
+- [Tic-Tac-Toe](http://github.com/davidrobles/mauler/blob/master/src/games/tic-tac-toe.js)
 
 Algorithms
 ----------


### PR DESCRIPTION
Fix the link to [Tic-Tac-Toe](http://github.com/davidrobles/mauler/blob/master/src/games/tic-tac-toe.js).